### PR TITLE
Move Dining Hall Selection to Customer Landing Page

### DIFF
--- a/frontend/src/components/CustomerLandingPage.vue
+++ b/frontend/src/components/CustomerLandingPage.vue
@@ -50,12 +50,25 @@
             >
               Track Current Order
             </button>
-            <RouterLink
-              to="/ItemPage"
-              class="action-btn primary-btn"
+          </div>
+
+          <div class="start-order-section">
+            <h3 class="start-order-title">Start Order</h3>
+            <label class="hall-label">Dining Hall</label>
+            <select v-model="hallSelection" class="hall-select">
+              <option value="" disabled>Select a dining hall</option>
+              <option value="Hampshire">Hampshire</option>
+              <option value="Berkshire">Berkshire</option>
+              <option value="Franklin">Franklin</option>
+              <option value="Worcester">Worcester</option>
+            </select>
+            <button
+              class="action-btn start-order-btn"
+              :disabled="!hallSelection"
+              @click="startOrder"
             >
-              Start New Order
-            </RouterLink>
+              Start Order
+            </button>
           </div>
         </div>
       </section>
@@ -97,10 +110,19 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
-import { RouterLink } from 'vue-router'
+import { useRouter } from 'vue-router'
+import { selectedHall } from './displayScripts/menuItems'
 
 const USER_ID = 1
 const BASE = 'http://localhost:8000'
+
+const router = useRouter()
+const hallSelection = ref('')
+
+function startOrder() {
+  selectedHall.value = hallSelection.value
+  router.push('/ItemPage')
+}
 
 // const profile = ref<any>(null)
 // const activeOrder = ref<any>(null)
@@ -326,6 +348,48 @@ onMounted(async () => {
   background: #4caf50;
   color: white;
   min-width: 90px;
+}
+
+.start-order-section {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-top: 1px solid #ececec;
+  padding-top: 16px;
+}
+
+.start-order-title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #111;
+}
+
+.hall-label {
+  font-weight: 600;
+  color: #333;
+}
+
+.hall-select {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #ccc;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.start-order-btn {
+  background: #4caf50;
+  color: white;
+}
+
+.start-order-btn:disabled {
+  background: #b0b0b0;
+  color: #e0e0e0;
+  cursor: not-allowed;
+  transform: none;
+  opacity: 1;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/components/CustomerLandingPage.vue
+++ b/frontend/src/components/CustomerLandingPage.vue
@@ -53,14 +53,32 @@
           </div>
 
           <div class="start-order-section">
-            <h3 class="start-order-title">Start Order</h3>
+            <h3 class="start-order-title">
+              Start Order
+            </h3>
             <label class="hall-label">Dining Hall</label>
-            <select v-model="hallSelection" class="hall-select">
-              <option value="" disabled>Select a dining hall</option>
-              <option value="Hampshire">Hampshire</option>
-              <option value="Berkshire">Berkshire</option>
-              <option value="Franklin">Franklin</option>
-              <option value="Worcester">Worcester</option>
+            <select
+              v-model="hallSelection"
+              class="hall-select"
+            >
+              <option
+                value=""
+                disabled
+              >
+                Select a dining hall
+              </option>
+              <option value="Hampshire">
+                Hampshire
+              </option>
+              <option value="Berkshire">
+                Berkshire
+              </option>
+              <option value="Franklin">
+                Franklin
+              </option>
+              <option value="Worcester">
+                Worcester
+              </option>
             </select>
             <button
               class="action-btn start-order-btn"

--- a/frontend/src/components/ItemPage.vue
+++ b/frontend/src/components/ItemPage.vue
@@ -1,9 +1,19 @@
 <template>
   <div class="page">
     <header class="top-bar">
-      <button class="back-btn" @click="goHome">&lt; BACK</button>
+      <button
+        class="back-btn"
+        @click="goHome"
+      >
+        &lt; BACK
+      </button>
       <h1>Grab &amp; Go Menu</h1>
-      <button class="start-over-btn" @click="startOver">Start Over</button>
+      <button
+        class="start-over-btn"
+        @click="startOver"
+      >
+        Start Over
+      </button>
     </header>
 
     <section class="filters">
@@ -65,8 +75,15 @@
       <section class="panel fixed-panel">
         <h2>Entrées</h2>
         <div class="panel-scroll">
-          <p v-if="loading">Loading menu...</p>
-          <p v-if="error" class="error">{{ error }}</p>
+          <p v-if="loading">
+            Loading menu...
+          </p>
+          <p
+            v-if="error"
+            class="error"
+          >
+            {{ error }}
+          </p>
           <ul v-if="filteredEntrees.length">
             <li
               v-for="item in filteredEntrees"
@@ -151,7 +168,7 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { selectedHall, selectedMeal, selectedDiet, loading, error, filteredEntrees, filteredSnacksAndDrinks, cart, cartTotal, formatTags, addToCart, removeFromCart, fetchMenuItems} from './displayScripts/menuItems'
+import { selectedMeal, selectedDiet, loading, error, filteredEntrees, filteredSnacksAndDrinks, cart, cartTotal, formatTags, addToCart, removeFromCart, fetchMenuItems} from './displayScripts/menuItems'
 
 const router = useRouter()
 

--- a/frontend/src/components/ItemPage.vue
+++ b/frontend/src/components/ItemPage.vue
@@ -3,14 +3,7 @@
     <header class="top-bar">
       <button class="back-btn" @click="goHome">&lt; BACK</button>
       <h1>Grab &amp; Go Menu</h1>
-      <div class="hall">Dining Hall:
-        <select class="red-select" v-model="selectedHall">
-          <option value="Hampshire">Hampshire</option>
-          <option value="Berkshire">Berkshire</option>
-          <option value="Franklin">Franklin</option>
-          <option value="Worcester">Worcester</option>
-        </select>
-      </div>
+      <button class="start-over-btn" @click="startOver">Start Over</button>
     </header>
 
     <section class="filters">
@@ -166,6 +159,10 @@ function goHome() {
   router.push('/')
 }
 
+function startOver() {
+  router.push('/customer')
+}
+
 onMounted(fetchMenuItems)
 </script>
 
@@ -198,14 +195,11 @@ onMounted(fetchMenuItems)
   font-size: 1.7rem;
 }
 
-.hall {
-  font-weight: 600;
-}
-
 .back-btn,
 .cart-tab-btn,
 .add-btn,
-.remove-btn {
+.remove-btn,
+.start-over-btn {
   border: none;
   border-radius: 10px;
   padding: 10px 14px;
@@ -214,7 +208,8 @@ onMounted(fetchMenuItems)
 }
 
 .back-btn,
-.cart-tab-btn {
+.cart-tab-btn,
+.start-over-btn {
   background: #e4e4e4;
 }
 
@@ -270,14 +265,6 @@ onMounted(fetchMenuItems)
 .orange-select {
   background: #f39c12;
   color: white;
-}
-
-.red-select {
-  background: red;
-  color: white;
-  font-weight: 600;
-  font-size: 1.1rem;
-  cursor: pointer;
 }
 
 .content {


### PR DESCRIPTION
- Moved the dining hall dropdown from the order/menu page to the customer landing page, under a new "Start Order" section
- The "Start Order" button is disabled and greyed out until a dining hall is selected, preventing users from reaching the menu without a hall chosen
- Replaced the dining hall dropdown on the item page with a "Start Over" button that navigates back to the customer landing page