### PR TITLE
Checkout rules and made it work

### DIFF
--- a/backend/app/services/menu_sync.py
+++ b/backend/app/services/menu_sync.py
@@ -27,15 +27,6 @@ _SNACK_KEYWORDS = (
 )
 
 
-def _category_from_station(station: str) -> str:
-    low = station.lower()
-    if any(k in low for k in _DRINK_KEYWORDS):
-        return "drink"
-    if any(k in low for k in _SNACK_KEYWORDS):
-        return "snack"
-    return "entree"
-
-
 def _category_from_item(name: str) -> str:
     low = name.lower()
     if any(k in low for k in _DRINK_KEYWORDS):

--- a/backend/app/services/menu_sync.py
+++ b/backend/app/services/menu_sync.py
@@ -7,14 +7,41 @@ from app.models import DiningHall, MenuItem
 from app.services import menu_cache
 from app.services.dining_scraper import HALL_IDS, fetch_menu
 
-_SNACK_KEYWORDS = ("dessert", "pastry", "fruit", "yogurt", "snack")
-_DRINK_KEYWORDS = ("beverage", "drink", "juice", "coffee", "tea", "milk")
+_DRINK_KEYWORDS = ("milk", "juice", "water", "coffee", "tea", "lemonade", "smoothie")
+_SNACK_PHRASES = ("tossed salad", "fruit salad")
+_SNACK_KEYWORDS = (
+    "brownie",
+    "cookie",
+    "muffin top",
+    "danish",
+    "parfait",
+    "oatmeal",
+    "cereal",
+    "broccoli",
+    "carrots",
+    "celery",
+    "squash",
+    "beans",
+    "garlic bread",
+    "yogurt",
+)
 
 
 def _category_from_station(station: str) -> str:
     low = station.lower()
     if any(k in low for k in _DRINK_KEYWORDS):
         return "drink"
+    if any(k in low for k in _SNACK_KEYWORDS):
+        return "snack"
+    return "entree"
+
+
+def _category_from_item(name: str) -> str:
+    low = name.lower()
+    if any(k in low for k in _DRINK_KEYWORDS):
+        return "drink"
+    if any(phrase in low for phrase in _SNACK_PHRASES):
+        return "snack"
     if any(k in low for k in _SNACK_KEYWORDS):
         return "snack"
     return "entree"
@@ -105,7 +132,7 @@ async def sync_today_menu_to_db(db: Session) -> None:
                         name=name,
                         meal_type=[effective_meal],
                         diets=diets,
-                        category=category,
+                        category=_category_from_item(name),
                         price=13.50,
                         dining_hall_id=dh.id,
                     )

--- a/backend/app/services/menu_sync.py
+++ b/backend/app/services/menu_sync.py
@@ -110,7 +110,6 @@ async def sync_today_menu_to_db(db: Session) -> None:
             for station, station_items in stations.items():
                 meal_name = str(meal_name)
                 station = str(station)
-                category = _category_from_station(station)
                 # Stations named "Breakfast *" are breakfast items even when
                 # the API nests them under the "lunch" meal key.
                 effective_meal = (

--- a/backend/app/services/menu_sync.py
+++ b/backend/app/services/menu_sync.py
@@ -106,7 +106,7 @@ async def sync_today_menu_to_db(db: Session) -> None:
                         meal_type=[effective_meal],
                         diets=diets,
                         category=category,
-                        price=0.0,
+                        price=13.50,
                         dining_hall_id=dh.id,
                     )
                     seen[key] = mi

--- a/frontend/src/components/ItemPage.vue
+++ b/frontend/src/components/ItemPage.vue
@@ -134,7 +134,12 @@
     </main>
 
     <section class="panel fixed-panel bottom-panel">
-      <h2>Snacks and Drinks</h2>
+      <div class="panel-heading">
+        <h2>Snacks and Drinks</h2>
+        <span class="side-counter">
+          {{ cartEntreeCount > 0 ? `${cartSideCount} / ${maxSides} sides used` : 'Add an entrée first' }}
+        </span>
+      </div>
       <div class="panel-scroll">
         <ul v-if="filteredSnacksAndDrinks.length">
           <li
@@ -147,6 +152,7 @@
             </div>
             <button
               class="add-btn green"
+              :disabled="!canAddSide"
               @click="addToCart(item)"
             >
               Add
@@ -164,7 +170,7 @@
 <script setup lang="ts">
 import { onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { type MealType, selectedHall, selectedMeal, selectedDiet, selectedDeliveryAddress, availableMeals, loading, error, filteredEntrees, filteredSnacksAndDrinks, cart, cartTotal, formatTags, addToCart, removeFromCart, fetchMenuItems} from './displayScripts/menuItems'
+import { type MealType, selectedHall, selectedMeal, selectedDiet, selectedDeliveryAddress, availableMeals, loading, error, filteredEntrees, filteredSnacksAndDrinks, cart, cartTotal, cartEntreeCount, cartSideCount, maxSides, canAddSide, formatTags, addToCart, removeFromCart, fetchMenuItems} from './displayScripts/menuItems'
 const router = useRouter()
 const route = useRoute()
 
@@ -388,6 +394,19 @@ async function handleCheckout() {
 
 .bottom-panel {
   height: 400px;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+
+.side-counter {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #888;
 }
 
 .panel h2 {

--- a/frontend/src/components/displayScripts/menuItems.ts
+++ b/frontend/src/components/displayScripts/menuItems.ts
@@ -21,6 +21,7 @@ export type CartItem = {
   id: number
   name: string
   price: number
+  category: 'entree' | 'snack' | 'drink'
 }
 
 export const items = ref<MenuItem[]>([])
@@ -198,16 +199,32 @@ export const filteredSnacksAndDrinks = computed(() => {
   return snacksAndDrinks.value.filter(matchesFilters)
 })
 
-export const cartTotal = computed(() => {
-  return cart.value.reduce((total: number, item: { price: number }) => total + item.price, 0).toFixed(2)
-})
+export const cartEntreeCount = computed(() =>
+  cart.value.filter(i => i.category === 'entree').length
+)
+
+export const cartSideCount = computed(() =>
+  cart.value.filter(i => i.category !== 'entree').length
+)
+
+export const maxSides = computed(() => cartEntreeCount.value * 4)
+
+export const canAddSide = computed(() =>
+  cartEntreeCount.value > 0 && cartSideCount.value < maxSides.value
+)
+
+export const cartTotal = computed(() =>
+  (cartEntreeCount.value * 13.50).toFixed(2)
+)
 
 export function addToCart(item: MenuItem): void {
+  if (item.category !== 'entree' && !canAddSide.value) return
   cart.value.push({
     cartId: nextCartId++,
     id: item.id,
     name: item.name,
-    price: item.price
+    price: item.category === 'entree' ? 13.50 : 0,
+    category: item.category,
   })
 }
 


### PR DESCRIPTION
Item categorization by name: Added _category_from_item() in menu_sync.py that classifies each scraped item as entree, snack, or drink based on item name keywords. Since UMass Grab n'Go uses a single station for all items, station-name-based categorization wasn't sufficient.
Meal swipe pricing: All scraped items are priced at $13.50 (one meal swipe). Cart total is calculated as entree count × $13.50 — sides and drinks are free add-ons.
Cart rules enforced in frontend: Added computed helpers (cartEntreeCount, cartSideCount, maxSides, canAddSide) and enforced the rule that sides/drinks can only be added after selecting an entree, with a max of 4 sides per entree. The Add button for sides is disabled when the limit is reached.