### PR TITLE
Start over button func fix

### DIFF
--- a/frontend/src/components/ItemPage.vue
+++ b/frontend/src/components/ItemPage.vue
@@ -170,7 +170,7 @@
 <script setup lang="ts">
 import { onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { type MealType, selectedHall, selectedMeal, selectedDiet, selectedDeliveryAddress, availableMeals, loading, error, filteredEntrees, filteredSnacksAndDrinks, cart, cartTotal, cartEntreeCount, cartSideCount, maxSides, canAddSide, formatTags, addToCart, removeFromCart, fetchMenuItems} from './displayScripts/menuItems'
+import { type MealType, selectedHall, selectedMeal, selectedDiet, selectedDeliveryAddress, availableMeals, loading, error, filteredEntrees, filteredSnacksAndDrinks, cart, cartTotal, cartEntreeCount, cartSideCount, maxSides, canAddSide, formatTags, addToCart, removeFromCart, clearCart, fetchMenuItems} from './displayScripts/menuItems'
 const router = useRouter()
 const route = useRoute()
 
@@ -179,6 +179,7 @@ function goHome() {
 }
 
 function startOver() {
+  clearCart()
   router.push('/CustomerLanding')
 }
 

--- a/frontend/src/components/displayScripts/menuItems.ts
+++ b/frontend/src/components/displayScripts/menuItems.ts
@@ -232,6 +232,10 @@ export function removeFromCart(cartId: number): void {
   cart.value = cart.value.filter((item: { cartId: number; }) => item.cartId !== cartId)
 }
 
+export function clearCart(): void {
+  cart.value = []
+}
+
 export function formatTags(item: MenuItem): string {
   const meals = item.mealType.join(', ')
   const diets = item.diets.length ? item.diets.join(', ') : 'none'


### PR DESCRIPTION
- startOver now calls clearCart before navigating back to the landing page, so switching dining halls always starts with a fresh cart
- Added clearCart utility function to menuItems.ts
